### PR TITLE
Fix how to called EventEmitter

### DIFF
--- a/libs/memcached_bclient.js
+++ b/libs/memcached_bclient.js
@@ -39,6 +39,7 @@
 var net = require('net');
 var util = require('util');
 var assert = require('assert');
+var events = require('events');
 
 /**
  * Memcached binary client
@@ -81,7 +82,7 @@ var MemcachedBinaryClient = function(server, params) {
   this.connect();
 };
 
-util.inherits(MemcachedBinaryClient, process.EventEmitter);
+util.inherits(MemcachedBinaryClient, events.EventEmitter);
 
 /**
  * Connect to the memcached server. Called automatically by the constructor.


### PR DESCRIPTION
Hello, test does not work.

My Environment.
 - macOS
 - Node.js v7.2.0

```bash
$ npm test

  #MemcachedBinaryClient
    #connection
      1) should create default server with default logger
      2) should create default server
Did not receive log expected to match "Memcached CONNECT: 11211,localhost open"
      3) "after each" hook for "should create default server"


  0 passing (19ms)
  3 failing

  1) #MemcachedBinaryClient #connection should create default server with default logger:
     TypeError: The super constructor to "inherits" must not be null or undefined
      at Object.exports.inherits (util.js:961:11)
      at Object.<anonymous> (libs/memcached_bclient.js:84:6)
      at Function.hookedLoader [as _load] (node_modules/mockery/mockery.js:111:12)
      at require (internal/module.js:20:19)
      at Context.<anonymous> (tests/unit/memcached_bclient.js:79:31)

  2) #MemcachedBinaryClient #connection should create default server:
     TypeError: The super constructor to "inherits" must not be null or undefined
      at Object.exports.inherits (util.js:961:11)
      at Object.<anonymous> (libs/memcached_bclient.js:84:6)
      at Function.hookedLoader [as _load] (node_modules/mockery/mockery.js:111:12)
      at require (internal/module.js:20:19)
      at mbcCreate (tests/unit/memcached_bclient.js:48:29)
      at Context.<anonymous> (tests/unit/memcached_bclient.js:86:17)
3) #MemcachedBinaryClient "after each" hook for "should create default server": 
      AssertionError: MockLogger: Expected a log message of type "log", but did not receive one
      + expected - actual

      -false
      +true

      at tests/mocks/mock_logger.js:42:14
      at Array.forEach (native)
      at MockLogger.checkExpectations (tests/mocks/mock_logger.js:37:13)
      at Context.<anonymous> (tests/unit/memcached_bclient.js:69:17)



npm ERR! Test failed.  See above for more details.
```